### PR TITLE
Removed activity

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,15 +8,6 @@
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:theme="@style/AppTheme">
-        <activity
-            android:name=".MainActivity"
-            android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
-            android:windowSoftInputMode="adjustResize">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-        </activity>
         <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
         <activity
             android:name=".ScannerActivity"


### PR DESCRIPTION
When using this library, we get two icons instead of one. This is caused by a [conflict](https://stackoverflow.com/questions/4620353/android-app-development-two-icons-getting-created-and-i-only-need-one) in this manifest file:

````
<intent-filter>
                <action android:name="android.intent.action.MAIN" />
                <category android:name="android.intent.category.LAUNCHER" />
            </intent-filter>
````
